### PR TITLE
Parser expand

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ TARGET				= minishell
 LEXER				= $(addprefix src/lexer/, lexer.c token.c)
 
 PARSER				= $(addprefix src/parser/, parser.c word.c redirection.c	\
-					  command.c pipe.c)
+					  command.c pipe.c expand.c)
 
 EXEC				= $(addprefix src/exec/, exec.c echo.c cd.c pwd.c export.c	\
 				  	unset.c env.c utils.c exit.c)

--- a/include/minishell/parser.h
+++ b/include/minishell/parser.h
@@ -35,6 +35,6 @@ void		parse_input_redirection(t_vector pipeline, t_lexer *lexer, char *token);
 t_command	*command_new(void);
 void		parse_pipe(t_vector pipeline, t_lexer *lexer, char *token);
 void		parse_word(t_vector pipeline, char *token);
-void		expand(char *word);
+void		expand(t_vector pipeline, char *word);
 
 #endif

--- a/include/minishell/parser.h
+++ b/include/minishell/parser.h
@@ -35,5 +35,6 @@ void		parse_input_redirection(t_vector pipeline, t_lexer *lexer, char *token);
 t_command	*command_new(void);
 void		parse_pipe(t_vector pipeline, t_lexer *lexer, char *token);
 void		parse_word(t_vector pipeline, char *token);
+void		expand(char *word);
 
 #endif

--- a/src/parser/expand.c
+++ b/src/parser/expand.c
@@ -1,10 +1,12 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 #include "libft/cstring.h"
+#include "libft/string.h"
 #include "libft/ctype.h"
 
-void	expand_var_in_quotes(char **expanded_ptr, char **word_loc)
+void	expand_var_in_quotes(t_string expanded, char **word_loc)
 {
 	char	*word;
 	char	*var;
@@ -17,16 +19,15 @@ void	expand_var_in_quotes(char **expanded_ptr, char **word_loc)
 		++i;
 	tmp = ft_substr(word, 1, i - 1);
 	var = getenv(tmp);
-	if (var == NULL)
-		return ;
-	tmp = *expanded_ptr;
-	*expanded_ptr = ft_strjoin(*expanded_ptr, var);
+	free(tmp);
+	if (var != NULL)
+		ft_string_append_cstr(expanded, var);
+	*word_loc += i;
 }
 
 void	expand(char *word)
 {
-	char			*expanded;
-	char			*expanded_ptr;
+	t_string		expanded;
 	unsigned char	quote;
 	size_t			i;
 	size_t			j;
@@ -34,8 +35,7 @@ void	expand(char *word)
 	i = 0;
 	j = 0;
 	quote = 0;
-	expanded = "";
-	expanded_ptr = expanded;
+	expanded = ft_string_new(ft_strlen(word) * 2);
 	while (*word != '\0')
 	{
 		if (*word == quote)
@@ -45,10 +45,9 @@ void	expand(char *word)
 		if (*word == '$' && *word != '\'')
 		{
 			if (quote == '"')
-				expand_var_in_quotes(&expanded_ptr, &word);
-			break ;
+				expand_var_in_quotes(expanded, &word);
 		}
-		++word;
+		ft_string_append_char(expanded, *word++);
 	}
-	printf("Expanded to => %s\n", expanded_ptr);
+	ft_string_output(expanded, STDOUT_FILENO);
 }

--- a/src/parser/expand.c
+++ b/src/parser/expand.c
@@ -1,0 +1,54 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "libft/cstring.h"
+#include "libft/ctype.h"
+
+void	expand_var_in_quotes(char **expanded_ptr, char **word_loc)
+{
+	char	*word;
+	char	*var;
+	char	*tmp;
+	size_t	i;
+	
+	word = *word_loc;
+	i = 0;
+	while (word[i] != '"' && !ft_isspace(word[i]))
+		++i;
+	tmp = ft_substr(word, 1, i - 1);
+	var = getenv(tmp);
+	if (var == NULL)
+		return ;
+	tmp = *expanded_ptr;
+	*expanded_ptr = ft_strjoin(*expanded_ptr, var);
+}
+
+void	expand(char *word)
+{
+	char			*expanded;
+	char			*expanded_ptr;
+	unsigned char	quote;
+	size_t			i;
+	size_t			j;
+
+	i = 0;
+	j = 0;
+	quote = 0;
+	expanded = "";
+	expanded_ptr = expanded;
+	while (*word != '\0')
+	{
+		if (*word == quote)
+			quote = 0;
+		else if (*word == '\'' || *word == '"')
+			quote = *word;
+		if (*word == '$' && *word != '\'')
+		{
+			if (quote == '"')
+				expand_var_in_quotes(&expanded_ptr, &word);
+			break ;
+		}
+		++word;
+	}
+	printf("Expanded to => %s\n", expanded_ptr);
+}

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -25,10 +25,7 @@ static void	parse(t_lexer *lexer, t_vector pipeline)
 		if (ft_vector_length(pipeline) == 0)
 			ft_vector_append(pipeline, command_new());
 		if (type == TOKEN_WORD)
-		{
-			expand(token);
-			parse_word(pipeline, token);
-		}
+			expand(pipeline, token);
 		else if (type == TOKEN_OR)
 			parse_pipe(pipeline, lexer, token);
 		else if (type == TOKEN_REDIRECTION_OUT)

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -25,7 +25,10 @@ static void	parse(t_lexer *lexer, t_vector pipeline)
 		if (ft_vector_length(pipeline) == 0)
 			ft_vector_append(pipeline, command_new());
 		if (type == TOKEN_WORD)
+		{
+			expand(token);
 			parse_word(pipeline, token);
+		}
 		else if (type == TOKEN_OR)
 			parse_pipe(pipeline, lexer, token);
 		else if (type == TOKEN_REDIRECTION_OUT)


### PR DESCRIPTION
Add experimental support for environment variable expansion, using the simple form (`$VAR`).
- support for unquoted variables, the same way bash handles it
- support for quoted variables (within double quotes only)