### PR TITLE
Parser refactor

### DIFF
--- a/include/minishell/env.h
+++ b/include/minishell/env.h
@@ -1,7 +1,10 @@
 #ifndef ENV_H
 # define ENV_H
+# include <stdbool.h>
+
 char	*minishell_getenv(char *var_name);
 char	*minishell_setenv(char *var_name, char *value);
 void	minishell_unsetenv(char *var_name);
 void	minishell_printenv(void);
+bool	is_valid_env_var_name(const char *name);
 #endif

--- a/include/minishell/error.h
+++ b/include/minishell/error.h
@@ -3,12 +3,13 @@
 
 typedef enum e_error
 {
+	ERROR_ERRNO = -1,
 	ERROR_BADALLOC = 0,
-	ERROR_UNTERMINATED_QUOTE,
 	ERROR_TRAILING_PIPE,
 	ERROR_MAX,
 }	t_error;
 
-int	error_print(t_error error);
+int		error_print(t_error error);
+void	error_fatal(t_error error);
 
 #endif

--- a/include/minishell/error.h
+++ b/include/minishell/error.h
@@ -11,5 +11,6 @@ typedef enum e_error
 
 int		error_print(t_error error);
 void	error_fatal(t_error error);
+void	*assert_ptr(void *p);
 
 #endif

--- a/include/minishell/minishell.h
+++ b/include/minishell/minishell.h
@@ -19,5 +19,6 @@ char	*prompt_present(const char *prompt);
 
 
 int		minishell_invoke(unsigned int opt, char **optargs, char **envp);
+void	minishell_exit(int exit_status);
 
 #endif

--- a/include/minishell/parser.h
+++ b/include/minishell/parser.h
@@ -36,6 +36,7 @@ t_command	*command_new(void);
 void		command_destroy(t_command *cmd);
 void		parse_pipe(t_vector pipeline, t_lexer *lexer, char *token);
 void		parse_word(t_vector pipeline, char *token);
+char		*word_strip_quotes(char *word);
 void		expand(t_vector pipeline, char *word);
 
 #endif

--- a/include/minishell/parser.h
+++ b/include/minishell/parser.h
@@ -29,13 +29,13 @@ typedef struct s_command
 
 t_vector	*parser_invoke(char *input);
 
-void		parse_output_redirection(t_vector pipeline, t_lexer *lexer,
+int			parse_output_redirection(t_vector pipeline, t_lexer *lexer,
 				char *token);
-void		parse_input_redirection(t_vector pipeline, t_lexer *lexer, char *token);
+int			parse_input_redirection(t_vector pipeline, t_lexer *lexer, char *token);
 t_command	*command_new(void);
 void		command_destroy(t_command *cmd);
-void		parse_pipe(t_vector pipeline, t_lexer *lexer, char *token);
-void		parse_word(t_vector pipeline, char *token);
+int			parse_pipe(t_vector pipeline, t_lexer *lexer, char *token);
+int			parse_word(t_vector pipeline, char *token);
 char		*word_strip_quotes(char *word);
 void		expand(t_vector pipeline, char *word);
 

--- a/include/minishell/parser.h
+++ b/include/minishell/parser.h
@@ -33,6 +33,7 @@ void		parse_output_redirection(t_vector pipeline, t_lexer *lexer,
 				char *token);
 void		parse_input_redirection(t_vector pipeline, t_lexer *lexer, char *token);
 t_command	*command_new(void);
+void		command_destroy(t_command *cmd);
 void		parse_pipe(t_vector pipeline, t_lexer *lexer, char *token);
 void		parse_word(t_vector pipeline, char *token);
 void		expand(t_vector pipeline, char *word);

--- a/include/minishell/stat.h
+++ b/include/minishell/stat.h
@@ -12,6 +12,7 @@ typedef struct s_stat
 	unsigned int	opt;
 	char			**optargs;
 	bool			error;
+	unsigned char	last_status_code;
 	t_argv			*env;
 }	t_stat;
 

--- a/src/env.c
+++ b/src/env.c
@@ -7,7 +7,30 @@
 #include "libft/io.h"
 #include "libft/cstring.h"
 #include "libft/core.h"
+#include "libft/ctype.h"
 #include <stdlib.h>
+
+/*
+** Check if name is a valid environment variable name. 
+** A valid variable name is any name composed of letters from the portable 
+** character set, digits, and underscores ('_').
+** - Lowercase and uppercase letters can be mixed up, even if it is not advisable.
+** - The name CAN contain digits but CAN'T start with one.
+**
+** REFERENCE: https://pubs.opengroup.org/onlinepubs/9699919799/
+*/
+
+bool	is_valid_env_var_name(const char *name)
+{
+	if (ft_isdigit(*name))
+		return (false);
+	while (*name != '\0')
+	{
+		if (*name != '_' && !ft_isalnum(*name++))
+			return (false);
+	}
+	return (true);
+}
 
 /*
 ** Because we do not have access to setenv or putenv, we need
@@ -29,19 +52,21 @@
 ** Example: minishell_getenv("HOME") => /home/abrabant
 */
 
-char *minishell_getenv(char *var_name)
+char *minishell_getenv(const char *name)
 {
 	t_argv	*env;
 	size_t	i;
-	size_t	var_name_len;
+	size_t	name_len;
 
+	if (!is_valid_env_var_name(name))
+		return (NULL);
 	env = stat_get()->env;
-	var_name_len = ft_strlen(var_name);
+	name_len = ft_strlen(name);
 	i = 0;
 	while (env->args[i] != NULL)
 	{
-		if (ft_strncmp(env->args[i], var_name, var_name_len) == 0)
-			return (env->args[i] + var_name_len + 1);
+		if (ft_strncmp(env->args[i], name, name_len) == 0)
+			return (env->args[i] + name_len + 1);
 		++i;
 	}
 	return (NULL);
@@ -54,26 +79,28 @@ char *minishell_getenv(char *var_name)
 ** Otherwise, the new variable is appended to the environment.
 */
 
-void minishell_setenv(char *var_name, char *value)
+void minishell_setenv(const char *name, char *value)
 {
 	t_argv	*env;
 	char	*entry;
 	size_t	i;
-	size_t	var_name_len;
+	size_t	name_len;
 	size_t	value_len;
 
+	if (!is_valid_env_var_name(name))
+		return ;
 	i = 0;
 	env = stat_get()->env;
-	var_name_len = ft_strlen(var_name);
+	name_len = ft_strlen(name);
 	value_len = ft_strlen(value);
 	entry = ft_gc_add(stat_get()->global_gc,
-			ft_calloc(var_name_len + value_len + 2, sizeof (*entry)), &free);
-	ft_strlcat(entry, var_name, var_name_len + 1);
-	ft_strlcat(entry, "=", var_name_len + 2);
-	ft_strlcat(entry, value, var_name_len + value_len + 2);
+			ft_calloc(name_len + value_len + 2, sizeof (*entry)), &free);
+	ft_strlcat(entry, name, name_len + 1);
+	ft_strlcat(entry, "=", name_len + 2);
+	ft_strlcat(entry, value, name_len + value_len + 2);
 	while (env->args[i] != NULL)
 	{
-		if (ft_strncmp(env->args[i], var_name, var_name_len) == 0)
+		if (ft_strncmp(env->args[i], name, name_len) == 0)
 		{
 				env->args[i] = entry;
 				return ;

--- a/src/env.c
+++ b/src/env.c
@@ -2,6 +2,7 @@
 
 #include "minishell/minishell.h"
 #include "minishell/stat.h"
+#include "minishell/error.h"
 //#include "minishell/stat.h"
 #include "libft/io.h"
 #include "libft/cstring.h"

--- a/src/error.c
+++ b/src/error.c
@@ -33,3 +33,10 @@ void	error_fatal(t_error error)
 {
 	minishell_exit(error_print(error));
 }
+
+void	*assert_ptr(void *p)
+{
+	if (p == NULL)
+		error_fatal(ERROR_BADALLOC);
+	return (p);
+}

--- a/src/error.c
+++ b/src/error.c
@@ -1,14 +1,16 @@
 #include <stdlib.h>
 #include <unistd.h>
+#include <sys/errno.h>
+#include <string.h>
 
 #include "libft/io.h"
 
+#include "minishell/minishell.h"
 #include "minishell/error.h"
 #include "minishell/stat.h"
 
 static const char	*g_error_messages[ERROR_MAX] = {
 	"Dynamic memory allocation failed",
-	"Found unterminated quotation",
 	"Found trailing pipe",
 };
 
@@ -18,6 +20,16 @@ static const char	*g_error_messages[ERROR_MAX] = {
 
 int	error_print(t_error error)
 {
+	if (error == ERROR_ERRNO)
+	{
+		ft_dprintf(STDERR_FILENO, "minishell: %s\n", strerror(errno));
+		return (errno);
+	}
 	ft_dprintf(STDERR_FILENO, "minishell: %s\n", g_error_messages[error]);
 	return (error + 1);
+}
+
+void	error_fatal(t_error error)
+{
+	minishell_exit(error_print(error));
 }

--- a/src/lexer/lexer.c
+++ b/src/lexer/lexer.c
@@ -270,6 +270,12 @@ t_token_type	token_get_type(char *token)
 ** Create and initialize a new lexer object
 */
 
+static void		lexer_destroy(t_lexer *lexer)
+{
+	ft_vector_destroy(lexer->tokenv, NULL);
+	free(lexer);
+}
+
 static t_lexer	*lexer_new(void)
 {
 	t_lexer	*lexer;
@@ -277,7 +283,7 @@ static t_lexer	*lexer_new(void)
 	lexer = malloc(sizeof (*lexer));
 	if (lexer == NULL)
 		return (NULL);
-	lexer->tokenv = ft_gc_add(stat_get()->tmp_gc, ft_vector_new(10), &free);
+	lexer->tokenv = ft_vector_new(10);
 	if (lexer->tokenv == NULL)
 	{ 
 		free(lexer);
@@ -294,7 +300,7 @@ t_lexer	*lexer_build(char *input)
 	unsigned char	quote;
 
 	i = 0;
-	lexer = lexer_new();
+	lexer = ft_gc_add(stat_get()->tmp_gc, lexer_new(), &lexer_destroy);
 	if (lexer == NULL)
 		return (NULL);
 	quote = 0;
@@ -315,7 +321,7 @@ t_lexer	*lexer_build(char *input)
 			++i;
 		}
 		if (i > 0)
-			ft_vector_append(lexer->tokenv, ft_substr(input, 0, i));
+			ft_vector_append(lexer->tokenv, ft_gc_add(stat_get()->tmp_gc, ft_substr(input, 0, i), &free));
 		input += i;
 		i = 0;
 	}

--- a/src/lexer/lexer.c
+++ b/src/lexer/lexer.c
@@ -8,6 +8,7 @@
 
 #include "minishell/lexer.h"
 #include "minishell/stat.h"
+#include "minishell/error.h"
 
 /*
 ** Character classes definition.
@@ -293,35 +294,46 @@ static t_lexer	*lexer_new(void)
 	return (lexer);
 }
 
+size_t	collect_token(char *input, size_t i, unsigned char *quote)
+{
+	t_token_type	type;
+
+	type = token_get_type(input);
+	while (chr_get_class(input[i]) != CHR_CLASS_EOL
+			&& (*quote || g_token_rules[type][chr_get_class(input[i])]))
+	{
+		if (chr_get_class(input[i]) == CHR_CLASS_QUOTE)
+		{
+			if (*quote == input[i])
+				*quote = 0;
+			else if (!quote)
+				*quote = input[i];
+		}
+		++i;
+	}
+	return (i);
+}
+
 t_lexer	*lexer_build(char *input)
 {
 	t_lexer			*lexer;
 	size_t			i;
 	unsigned char	quote;
+	char			*token;
 
 	i = 0;
-	lexer = ft_gc_add(stat_get()->tmp_gc, lexer_new(), &lexer_destroy);
-	if (lexer == NULL)
-		return (NULL);
+	lexer = ft_gc_add(stat_get()->tmp_gc,
+			assert_ptr(lexer_new()), &lexer_destroy);
 	quote = 0;
 	while (chr_get_class(input[i]) != CHR_CLASS_EOL)
 	{
 		while (chr_get_class(input[i]) == CHR_CLASS_BLANK)
 			++input;
-		while (chr_get_class(input[i]) != CHR_CLASS_EOL
-				&& (quote || g_token_rules[token_get_type(input)][chr_get_class(input[i])]))
-		{
-			if (chr_get_class(input[i]) == CHR_CLASS_QUOTE)
-			{
-				if (quote == input[i])
-					quote = 0;
-				else if (!quote)
-					quote = input[i];
-			}
-			++i;
-		}
+		i = collect_token(input, i, &quote);
+		token = assert_ptr(ft_substr(input, 0, i));
 		if (i > 0)
-			ft_vector_append(lexer->tokenv, ft_gc_add(stat_get()->tmp_gc, ft_substr(input, 0, i), &free));
+			ft_vector_append(lexer->tokenv,
+					ft_gc_add(stat_get()->tmp_gc, token, &free));
 		input += i;
 		i = 0;
 	}

--- a/src/lexer/lexer.c
+++ b/src/lexer/lexer.c
@@ -306,7 +306,7 @@ size_t	collect_token(char *input, size_t i, unsigned char *quote)
 		{
 			if (*quote == input[i])
 				*quote = 0;
-			else if (!quote)
+			else if (!*quote)
 				*quote = input[i];
 		}
 		++i;
@@ -330,10 +330,12 @@ t_lexer	*lexer_build(char *input)
 		while (chr_get_class(input[i]) == CHR_CLASS_BLANK)
 			++input;
 		i = collect_token(input, i, &quote);
-		token = assert_ptr(ft_substr(input, 0, i));
 		if (i > 0)
+		{
+			token = assert_ptr(ft_substr(input, 0, i));
 			ft_vector_append(lexer->tokenv,
 					ft_gc_add(stat_get()->tmp_gc, token, &free));
+		}
 		input += i;
 		i = 0;
 	}

--- a/src/minishell.c
+++ b/src/minishell.c
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include <stdio.h>
 
 #include "libft/io.h"
 
@@ -24,11 +25,18 @@ int	minishell_invoke(unsigned int opt, char **optargs, char **envp)
 	while (1)
 	{
 		cmd = prompt_present("\033[0;33mminishell\033[0m-1.0$ ");
+		if (cmd == NULL)
+			continue ;
 		parsed = parser_invoke(cmd);
 		exec(parsed);
 		ft_gc_wipe(stat_get()->tmp_gc);
 	}
-	ft_gc_destroy(stat_get()->tmp_gc);
-	stat_destroy();
+	minishell_exit(EXIT_SUCCESS);
 	return (0);
+}
+
+void	minishell_exit(int exit_status)
+{
+	stat_destroy();
+	exit(exit_status);
 }

--- a/src/minishell.c
+++ b/src/minishell.c
@@ -28,7 +28,8 @@ int	minishell_invoke(unsigned int opt, char **optargs, char **envp)
 		if (cmd == NULL)
 			continue ;
 		parsed = parser_invoke(cmd);
-		exec(parsed);
+		if (parsed != NULL)
+			exec(parsed);
 		ft_gc_wipe(stat_get()->tmp_gc);
 	}
 	minishell_exit(EXIT_SUCCESS);

--- a/src/parser/command.c
+++ b/src/parser/command.c
@@ -1,3 +1,5 @@
+#include <stdlib.h>
+
 #include "libft/core.h"
 
 #include "minishell/parser.h"
@@ -10,4 +12,12 @@ t_command	*command_new(void)
 	cmd->argv = argv_new(5);
 	cmd->redir_out = ft_vector_new(2);
 	return (cmd);
+}
+
+void	command_destroy(t_command *cmd)
+{
+	ft_vector_destroy(cmd->redir_out, &free);
+	free(cmd->redir_in);
+	argv_destroy(cmd->argv, (void *)(char *)&free);
+	free(cmd);
 }

--- a/src/parser/expand.c
+++ b/src/parser/expand.c
@@ -5,6 +5,7 @@
 #include "minishell/parser.h"
 #include "minishell/env.h"
 #include "minishell/stat.h"
+#include "minishell/error.h"
 
 #include "libft/cstring.h"
 #include "libft/gc.h"
@@ -22,7 +23,7 @@ void	expand_var_in_quotes(t_string expanded, char **word_loc)
 	i = 1;
 	while (ft_isalnum(word[i]))
 		++i;
-	tmp = ft_substr(word, 1, i - 1);
+	tmp = assert_ptr(ft_substr(word, 1, i - 1));
 	var = minishell_getenv(tmp);
 	free(tmp);
 	if (var != NULL)
@@ -35,7 +36,7 @@ static void	tokenize_var(t_vector pipeline, t_string *expanded, char *var)
 	char	*token;
 	char	*tmp;
 
-	var = ft_strdup(var);
+	var = assert_ptr(ft_strdup(var));
 	token = ft_strtok(var, " \t");
 	tmp = token;
 	while (token != NULL)
@@ -44,16 +45,16 @@ static void	tokenize_var(t_vector pipeline, t_string *expanded, char *var)
 		if (tmp == NULL)
 		{
 			if (token != var)
-				*expanded = ft_string_new(10);
+				ft_string_set_length(*expanded, 0);
 			ft_string_append_cstr(*expanded, token);
 		}
 		else if (token == var)
 		{
 			ft_string_append_cstr(*expanded, token);
-			parse_word(pipeline, ft_string_tocstring(*expanded));
+			parse_word(pipeline, assert_ptr(ft_string_tocstring(*expanded)));
 		}
 		else
-			parse_word(pipeline, ft_strdup(token));
+			parse_word(pipeline, assert_ptr(ft_strdup(token)));
 		token = tmp;
 	}
 }
@@ -69,7 +70,7 @@ void	expand_unquoted_var(t_vector pipeline, t_string *expanded, char **word_loc)
 	i = 1;
 	while (ft_isalnum(word[i]) && !ft_isspace(word[i]))
 		++i;
-	tmp = ft_substr(word, 1, i - 1);
+	tmp = assert_ptr(ft_substr(word, 1, i - 1));
 	var = minishell_getenv(tmp);
 	free(tmp);
 	*word_loc += i;
@@ -87,8 +88,8 @@ void	expand(t_vector pipeline, char *word)
 	i = 0;
 	j = 0;
 	quote = 0;
-	expanded = ft_gc_add(stat_get()->tmp_gc, ft_string_new(ft_strlen(word) * 2),
-			(void *)(void *)&ft_string_destroy);
+	expanded = ft_gc_add(stat_get()->tmp_gc, assert_ptr(ft_string_new
+				(ft_strlen(word) * 2)), (void *)(void *)&ft_string_destroy);
 	while (*word != '\0')
 	{
 		if (*word == quote)
@@ -105,5 +106,5 @@ void	expand(t_vector pipeline, char *word)
 		else if (*word != '\0')
 			ft_string_append_char(expanded, *word++);
 	}
-	parse_word(pipeline, ft_string_tocstring(expanded));
+	parse_word(pipeline, assert_ptr(ft_string_tocstring(expanded)));
 }

--- a/src/parser/expand.c
+++ b/src/parser/expand.c
@@ -4,8 +4,10 @@
 
 #include "minishell/parser.h"
 #include "minishell/env.h"
+#include "minishell/stat.h"
 
 #include "libft/cstring.h"
+#include "libft/gc.h"
 #include "libft/string.h"
 #include "libft/ctype.h"
 
@@ -85,14 +87,15 @@ void	expand(t_vector pipeline, char *word)
 	i = 0;
 	j = 0;
 	quote = 0;
-	expanded = ft_string_new(ft_strlen(word) * 2);
+	expanded = ft_gc_add(stat_get()->tmp_gc, ft_string_new(ft_strlen(word) * 2),
+			(void *)(void *)&ft_string_destroy);
 	while (*word != '\0')
 	{
 		if (*word == quote)
 			quote = 0;
 		else if (!quote && (*word == '\'' || *word == '"'))
 			quote = *word;
-		if (*word == '$' && quote != '\'')
+		if (quote != '\'' && word[0] == '$' && word[1] != '\0')
 		{
 			if (quote == '"')
 				expand_var_in_quotes(expanded, &word);

--- a/src/parser/expand.c
+++ b/src/parser/expand.c
@@ -68,12 +68,14 @@ void	expand_unquoted_var(t_vector pipeline, t_string *expanded, char **word_loc)
 	
 	word = *word_loc;
 	i = 1;
-	while (ft_isalnum(word[i]) && !ft_isspace(word[i]))
+	while (ft_isalnum(word[i]))
 		++i;
+	*word_loc += i;
+	if (i == 1)
+		return ;
 	tmp = assert_ptr(ft_substr(word, 1, i - 1));
 	var = minishell_getenv(tmp);
 	free(tmp);
-	*word_loc += i;
 	if (var != NULL)
 		tokenize_var(pipeline, expanded, var);
 }
@@ -100,7 +102,7 @@ void	expand(t_vector pipeline, char *word)
 		{
 			if (quote == '"')
 				expand_var_in_quotes(expanded, &word);
-			if (!quote)
+			else if (!quote)
 				expand_unquoted_var(pipeline, &expanded, &word);
 		}
 		else if (*word != '\0')

--- a/src/parser/expand.c
+++ b/src/parser/expand.c
@@ -9,6 +9,7 @@
 
 #include "libft/cstring.h"
 #include "libft/gc.h"
+#include "libft/io.h"
 #include "libft/string.h"
 #include "libft/ctype.h"
 
@@ -80,6 +81,24 @@ void	expand_unquoted_var(t_vector pipeline, t_string *expanded, char **word_loc)
 		tokenize_var(pipeline, expanded, var);
 }
 
+void	expand_env_variable(t_vector pipeline, t_string *expanded,
+		char **word_loc, unsigned char quote)
+{
+	char	status[4];
+
+	if ((*word_loc)[1] == '?')
+	{
+		ft_snprintf(status, sizeof (status), "%hhu",
+				stat_get()->last_status_code);
+		ft_string_append_cstr(*expanded, status);
+		*word_loc += 2;
+	}
+	else if (quote == '"')
+		expand_var_in_quotes(expanded, word_loc);
+	else if (!quote)
+		expand_unquoted_var(pipeline, expanded, word_loc);
+}
+
 void	expand(t_vector pipeline, char *word)
 {
 	t_string		expanded;
@@ -99,14 +118,10 @@ void	expand(t_vector pipeline, char *word)
 		else if (!quote && (*word == '\'' || *word == '"'))
 			quote = *word;
 		if (quote != '\'' && word[0] == '$' && word[1] != '\0')
-		{
-			if (quote == '"')
-				expand_var_in_quotes(expanded, &word);
-			else if (!quote)
-				expand_unquoted_var(pipeline, &expanded, &word);
-		}
+			expand_env_variable(pipeline, &expanded, &word, quote);
 		else if (*word != '\0')
 			ft_string_append_char(expanded, *word++);
 	}
-	parse_word(pipeline, assert_ptr(ft_string_tocstring(expanded)));
+	if (ft_string_length(expanded) > 0)
+		parse_word(pipeline, assert_ptr(ft_string_tocstring(expanded)));
 }

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -37,6 +37,7 @@ static void	parse(t_lexer *lexer, t_vector pipeline)
 	}
 }
 
+/*
 static int	print_command(t_command *cmd, int index)
 {
 	printf("COMMAND %d\n", index);
@@ -51,6 +52,12 @@ static int	print_command(t_command *cmd, int index)
 	}
 	return (0);
 }
+*/
+
+static void	destroy_pipeline(t_vector pipeline)
+{
+	ft_vector_destroy(pipeline, (void *)(void *)&command_destroy);
+}
 
 t_vector	*parser_invoke(char *input)
 {
@@ -58,10 +65,10 @@ t_vector	*parser_invoke(char *input)
 	t_vector			pipeline;
 
 	lexer = lexer_build(input);
-	pipeline = ft_vector_new(5);
+	pipeline = ft_gc_add(stat_get()->tmp_gc, ft_vector_new(5), &destroy_pipeline);
 	if (pipeline == NULL)
 		return (NULL);
 	parse(lexer, pipeline);
-	ft_vector_foreach(pipeline, &print_command, NULL);
+	//ft_vector_foreach(pipeline, &print_command, NULL);
 	return (pipeline);
 }

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -37,7 +37,6 @@ static void	parse(t_lexer *lexer, t_vector pipeline)
 	}
 }
 
-/*
 static int	print_command(t_command *cmd, int index)
 {
 	printf("COMMAND %d\n", index);
@@ -52,7 +51,6 @@ static int	print_command(t_command *cmd, int index)
 	}
 	return (0);
 }
-*/
 
 static void	destroy_pipeline(t_vector pipeline)
 {
@@ -68,6 +66,6 @@ t_vector	*parser_invoke(char *input)
 	pipeline = ft_gc_add(stat_get()->tmp_gc,
 			assert_ptr(ft_vector_new(5)), &destroy_pipeline);
 	parse(lexer, pipeline);
-	//ft_vector_foreach(pipeline, &print_command, NULL);
+	ft_vector_foreach(pipeline, &print_command, NULL);
 	return (pipeline);
 }

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -23,7 +23,7 @@ static void	parse(t_lexer *lexer, t_vector pipeline)
 	while (type != TOKEN_ERROR)
 	{
 		if (ft_vector_length(pipeline) == 0)
-			ft_vector_append(pipeline, command_new());
+			ft_vector_append(pipeline, assert_ptr(command_new()));
 		if (type == TOKEN_WORD)
 			expand(pipeline, token);
 		else if (type == TOKEN_OR)
@@ -65,9 +65,8 @@ t_vector	*parser_invoke(char *input)
 	t_vector			pipeline;
 
 	lexer = lexer_build(input);
-	pipeline = ft_gc_add(stat_get()->tmp_gc, ft_vector_new(5), &destroy_pipeline);
-	if (pipeline == NULL)
-		return (NULL);
+	pipeline = ft_gc_add(stat_get()->tmp_gc,
+			assert_ptr(ft_vector_new(5)), &destroy_pipeline);
 	parse(lexer, pipeline);
 	//ft_vector_foreach(pipeline, &print_command, NULL);
 	return (pipeline);

--- a/src/parser/pipe.c
+++ b/src/parser/pipe.c
@@ -3,7 +3,7 @@
 #include "libft/cstring.h"
 #include "libft/io.h"
 
-#include "minishell/lexer.h"
+#include "minishell/error.h"
 #include "minishell/parser.h"
 
 void	parse_pipe(t_vector pipeline, t_lexer *lexer, char *token)
@@ -18,5 +18,5 @@ void	parse_pipe(t_vector pipeline, t_lexer *lexer, char *token)
 		ft_dprintf(STDERR_FILENO, "minishell: trailing pipe\n", token);
 		return ;
 	}
-	ft_vector_append(pipeline, command_new());
+	ft_vector_append(pipeline, assert_ptr(command_new()));
 }

--- a/src/parser/pipe.c
+++ b/src/parser/pipe.c
@@ -6,17 +6,18 @@
 #include "minishell/error.h"
 #include "minishell/parser.h"
 
-void	parse_pipe(t_vector pipeline, t_lexer *lexer, char *token)
+int	parse_pipe(t_vector pipeline, t_lexer *lexer, char *token)
 {
 	if (ft_strlen(token) > 1)
 	{
 		ft_dprintf(STDERR_FILENO, "minishell: %s: unknown operator\n", token);
-		return ;
+		return (1);
 	}
 	if (token_get_next(lexer, &token) == TOKEN_ERROR)
 	{
 		ft_dprintf(STDERR_FILENO, "minishell: trailing pipe\n", token);
-		return ;
+		return (2);
 	}
 	ft_vector_append(pipeline, assert_ptr(command_new()));
+	return (0);
 }

--- a/src/parser/redirection.c
+++ b/src/parser/redirection.c
@@ -35,7 +35,7 @@ static t_redirection	*redirection_new(void)
 	return (redirection);
 }
 
-void	parse_output_redirection(t_vector pipeline, t_lexer *lexer, char *token)
+int	parse_output_redirection(t_vector pipeline, t_lexer *lexer, char *token)
 {
 	t_command		*cmd;
 	t_redirection	*redir;
@@ -44,7 +44,7 @@ void	parse_output_redirection(t_vector pipeline, t_lexer *lexer, char *token)
 	if (ft_strcmp(token, ">") != 0 && ft_strcmp(token, ">>") != 0)
 	{
 		ft_dprintf(STDERR_FILENO, "minishell: %s: invalid output redirection\n", token);
-		return ;
+		return (1);
 	}
 	redir = assert_ptr(redirection_new());
 	redir->type = redirection_get_type(token);
@@ -52,11 +52,12 @@ void	parse_output_redirection(t_vector pipeline, t_lexer *lexer, char *token)
 	if (token_get_next(lexer, &token) != TOKEN_WORD)
 	{
 		ft_dprintf(STDERR_FILENO, "minishell: %s: valid arg required\n", token);
-		return ;
+		return (2);
 	}
+	return (0);
 }
 
-void	parse_input_redirection(t_vector pipeline, t_lexer *lexer, char *token)
+int	parse_input_redirection(t_vector pipeline, t_lexer *lexer, char *token)
 {
 	t_command	*cmd;
 
@@ -64,7 +65,7 @@ void	parse_input_redirection(t_vector pipeline, t_lexer *lexer, char *token)
 	if (ft_strcmp(token, "<") != 0 && ft_strcmp(token, "<<") != 0)
 	{
 		ft_dprintf(STDERR_FILENO, "minishell: %s: invalid input redirection\n", token);
-		return ;
+		return (1);
 	}
 	if (cmd->redir_in == NULL)
 		cmd->redir_in = assert_ptr(redirection_new());
@@ -72,6 +73,7 @@ void	parse_input_redirection(t_vector pipeline, t_lexer *lexer, char *token)
 	if (token_get_next(lexer, &token) != TOKEN_WORD)
 	{
 		ft_dprintf(STDERR_FILENO, "minishell: %s: valid arg required\n", token);
-		return ;
+		return (2);
 	}
+	return (0);
 }

--- a/src/parser/redirection.c
+++ b/src/parser/redirection.c
@@ -5,6 +5,7 @@
 #include "libft/io.h"
 
 #include "minishell/parser.h"
+#include "minishell/error.h"
 
 static t_redirecton_type	redirection_get_type(char *token)
 {
@@ -45,7 +46,7 @@ void	parse_output_redirection(t_vector pipeline, t_lexer *lexer, char *token)
 		ft_dprintf(STDERR_FILENO, "minishell: %s: invalid output redirection\n", token);
 		return ;
 	}
-	redir = redirection_new();
+	redir = assert_ptr(redirection_new());
 	redir->type = redirection_get_type(token);
 	ft_vector_append(cmd->redir_out, redir);
 	if (token_get_next(lexer, &token) != TOKEN_WORD)
@@ -66,7 +67,7 @@ void	parse_input_redirection(t_vector pipeline, t_lexer *lexer, char *token)
 		return ;
 	}
 	if (cmd->redir_in == NULL)
-		cmd->redir_in = redirection_new();
+		cmd->redir_in = assert_ptr(redirection_new());
 	cmd->redir_in->type = redirection_get_type(token);
 	if (token_get_next(lexer, &token) != TOKEN_WORD)
 	{

--- a/src/parser/word.c
+++ b/src/parser/word.c
@@ -30,7 +30,7 @@ char	*word_strip_quotes(char *word)
 	return (stripped);
 }
 
-void	parse_word(t_vector pipeline, char *token)
+int	parse_word(t_vector pipeline, char *token)
 {
 	t_command		*cmd;
 	t_redirection	*last_out_redir;
@@ -46,4 +46,5 @@ void	parse_word(t_vector pipeline, char *token)
 		last_out_redir->arg = token;
 	else
 		argv_append(cmd->argv, token);
+	return (0);
 }

--- a/src/parser/word.c
+++ b/src/parser/word.c
@@ -5,7 +5,7 @@
 
 #include "minishell/parser.h"
 
-static char	*word_strip_quotes(char *word)
+char	*word_strip_quotes(char *word)
 {
 	unsigned char	quote;
 	char			*stripped;
@@ -27,7 +27,6 @@ static char	*word_strip_quotes(char *word)
 		++j;
 	}
 	stripped[i] = '\0';
-	free(word);
 	return (stripped);
 }
 

--- a/src/prompt.c
+++ b/src/prompt.c
@@ -31,7 +31,7 @@ char	*prompt_present(const char *prompt)
 {
 	char	*line;
 
-	line = readline(prompt);
+	line = ft_gc_add(stat_get()->tmp_gc, readline(prompt), &free);
 	if (!is_line_blank(line))
 		add_history(line);
 	return (line);

--- a/src/stat.c
+++ b/src/stat.c
@@ -19,6 +19,7 @@ void	stat_init(unsigned int opt, char **optargs, char **envp)
 	stat_get()->tmp_gc = ft_gc_new();
 	stat_get()->error = false;
 	stat_get()->env = argv_new(70);
+	stat_get()->last_status_code = 0;
 	while (*envp != NULL)
 		argv_append(stat_get()->env, *envp++);
 }

--- a/src/stat.c
+++ b/src/stat.c
@@ -27,4 +27,5 @@ void	stat_destroy(void)
 {
 	ft_gc_destroy(stat_get()->tmp_gc);
 	ft_gc_destroy(stat_get()->global_gc);
+	argv_destroy(stat_get()->env, NULL);
 }


### PR DESCRIPTION
Global refactor for parsed related stuff. This PR introduces a few changes:

- New env function, `is_valid_env_var_name` to check if a variable name is correct.
- Adds support for the `$?` special expansion
- Adds `error_fatal`, `minishell_exit`, `assert_ptr` to improve error and resource management.
- Any parsing error will now immediately stop the parser and the prompt will be given back to the user immediately without any execution (trailing pipe, invalid operator, no argument for redirection...)
- Memory should be freed correctly when a command has been executed and when the shell is exited.
- Fixed expansion issue with invalid variable identifiers